### PR TITLE
Fixed issue with duplicated class names after obfuscation 

### DIFF
--- a/Android/cleeng/proguard-rules.pro
+++ b/Android/cleeng/proguard-rules.pro
@@ -68,3 +68,4 @@
 -keepclasseswithmembers, allowobfuscation class * {
     @retrofit2.http.* <methods>;
 }
+-repackageclasses com.applicaster.cleeng


### PR DESCRIPTION
Fixed issue with duplicated class names after obfuscation and build with specific plugin